### PR TITLE
Improve Figma hierarchy tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ The MCP server provides the following tools for interacting with Figma:
 - `read_my_design` - Get detailed node information about the current selection without parameters
 - `get_node_info` - Get detailed information about a specific node
 - `get_nodes_info` - Get detailed information about multiple nodes by providing an array of node IDs
+- `get_node_tree` - Get the hierarchical tree of a node and its children
+- `get_current_page_tree` - Inspect the full layer tree of the current page
 
 ### Annotations
 
@@ -171,6 +173,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `delete_node` - Delete a node
 - `delete_multiple_nodes` - Delete multiple nodes at once efficiently
 - `clone_node` - Create a copy of an existing node with optional position offset
+- `clone_node_with_map` - Clone a node and return a mapping of original IDs to the new clone
 
 ### Components & Styles
 

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -229,6 +229,12 @@ async function handleCommand(command, params) {
       return await setDefaultConnector(params);
     case "create_connections":
       return await createConnections(params);
+    case "clone_node_with_map":
+      return await cloneNodeWithMap(params);
+    case "get_node_tree":
+      return await getNodeTree(params);
+    case "get_current_page_tree":
+      return await getCurrentPageTree();
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -1665,6 +1671,82 @@ async function cloneNode(params) {
     width: "width" in clone ? clone.width : undefined,
     height: "height" in clone ? clone.height : undefined,
   };
+}
+
+// Clone node and return mapping from original IDs to clone IDs
+async function cloneNodeWithMap(params) {
+  const { nodeId, x, y } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  const clone = node.clone();
+
+  if (x !== undefined && y !== undefined) {
+    if ("x" in clone && "y" in clone) {
+      clone.x = x;
+      clone.y = y;
+    }
+  }
+
+  if (node.parent) {
+    node.parent.appendChild(clone);
+  } else {
+    figma.currentPage.appendChild(clone);
+  }
+
+  const idMap = {};
+  function mapIds(orig, dup) {
+    idMap[orig.id] = dup.id;
+    if ("children" in orig && "children" in dup) {
+      for (let i = 0; i < orig.children.length; i++) {
+        mapIds(orig.children[i], dup.children[i]);
+      }
+    }
+  }
+  mapIds(node, clone);
+
+  return {
+    id: clone.id,
+    name: clone.name,
+    idMap,
+  };
+}
+
+// Get hierarchical tree for a node
+async function getNodeTree(params) {
+  const { nodeId } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId parameter");
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found with ID: ${nodeId}`);
+
+  function traverse(n) {
+    const info = { id: n.id, name: n.name, type: n.type };
+    if ("children" in n) {
+      info.children = n.children.map(traverse);
+    }
+    return info;
+  }
+  return traverse(node);
+}
+
+// Get hierarchical tree for the current page
+async function getCurrentPageTree() {
+  const page = figma.currentPage;
+  function traverse(n) {
+    const info = { id: n.id, name: n.name, type: n.type };
+    if ("children" in n) {
+      info.children = n.children.map(traverse);
+    }
+    return info;
+  }
+  return traverse(page);
 }
 
 async function scanTextNodes(params) {

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -353,6 +353,66 @@ server.tool(
   }
 );
 
+// Node Tree Tool
+server.tool(
+  "get_node_tree",
+  "Get the hierarchical tree of a node and its children",
+  {
+    nodeId: z.string().describe("ID of the node to inspect")
+  },
+  async ({ nodeId }) => {
+    try {
+      const result = await sendCommandToFigma("get_node_tree", { nodeId });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting node tree: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Current Page Tree Tool
+server.tool(
+  "get_current_page_tree",
+  "Get the hierarchical tree of the current page",
+  {},
+  async () => {
+    try {
+      const result = await sendCommandToFigma("get_current_page_tree", {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting page tree: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
 
 // Create Rectangle Tool
 server.tool(
@@ -747,6 +807,39 @@ server.tool(
           {
             type: "text",
             text: `Error cloning node: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Clone Node with Map Tool
+server.tool(
+  "clone_node_with_map",
+  "Clone a node and get a mapping of original IDs to cloned IDs",
+  {
+    nodeId: z.string().describe("The ID of the node to clone"),
+    x: z.number().optional().describe("New X position for the clone"),
+    y: z.number().optional().describe("New Y position for the clone")
+  },
+  async ({ nodeId, x, y }) => {
+    try {
+      const result = await sendCommandToFigma('clone_node_with_map', { nodeId, x, y });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error cloning node with map: ${error instanceof Error ? error.message : String(error)}`
           }
         ]
       };


### PR DESCRIPTION
## Summary
- expose more hierarchy info from the plugin
- support cloning nodes with ID mapping
- surface new capabilities in the MCP server
- document new commands in README

## Testing
- `bun run build` *(fails: tsup not found)*