### PR TITLE
Improve Figma selection tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,9 +121,12 @@ The MCP server provides the following tools for interacting with Figma:
 
 - `get_document_info` - Get information about the current Figma document
 - `get_selection` - Get information about the current selection
+- `select_nodes` - Select nodes on the canvas by their IDs
 - `read_my_design` - Get detailed node information about the current selection without parameters
 - `get_node_info` - Get detailed information about a specific node
 - `get_nodes_info` - Get detailed information about multiple nodes by providing an array of node IDs
+- `get_node_tree` - Get the hierarchical tree of a node and its children
+- `get_current_page_tree` - Inspect the full layer tree of the current page
 
 ### Annotations
 
@@ -171,6 +174,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `delete_node` - Delete a node
 - `delete_multiple_nodes` - Delete multiple nodes at once efficiently
 - `clone_node` - Create a copy of an existing node with optional position offset
+- `clone_node_with_map` - Clone a node and return a mapping of original IDs to the new clone
 
 ### Components & Styles
 
@@ -183,6 +187,7 @@ The MCP server provides the following tools for interacting with Figma:
 ### Export & Advanced
 
 - `export_node_as_image` - Export a node as an image (PNG, JPG, SVG, or PDF) - limited support on image currently returning base64 as text
+- `get_selection_base64` - Export the current selection as a JPG and return the base64 encoding
 
 ### Connection Management
 

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -229,6 +229,16 @@ async function handleCommand(command, params) {
       return await setDefaultConnector(params);
     case "create_connections":
       return await createConnections(params);
+    case "select_nodes":
+      return await selectNodes(params);
+    case "get_selection_base64":
+      return await getSelectionBase64(params);
+    case "clone_node_with_map":
+      return await cloneNodeWithMap(params);
+    case "get_node_tree":
+      return await getNodeTree(params);
+    case "get_current_page_tree":
+      return await getCurrentPageTree();
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -1248,6 +1258,63 @@ async function exportNodeAsImage(params) {
     throw new Error(`Error exporting node as image: ${error.message}`);
   }
 }
+
+// Select nodes on the canvas by their IDs
+async function selectNodes(params) {
+  const { nodeIds } = params || {};
+  if (!nodeIds || !Array.isArray(nodeIds)) {
+    throw new Error("Missing or invalid nodeIds parameter");
+  }
+
+  const nodes = [];
+  for (const id of nodeIds) {
+    const node = await figma.getNodeByIdAsync(id);
+    if (node) nodes.push(node);
+  }
+
+  figma.currentPage.selection = nodes;
+  if (nodes.length > 0) {
+    figma.viewport.scrollAndZoomIntoView(nodes);
+  }
+
+  return {
+    selectedCount: nodes.length,
+    selectedIds: nodes.map((n) => n.id),
+  };
+}
+
+// Export the current selection as a JPG and return base64 string
+async function getSelectionBase64(params) {
+  const { scale = 1 } = params || {};
+  const selection = figma.currentPage.selection;
+  if (selection.length === 0) {
+    throw new Error("No nodes selected");
+  }
+
+  // Create a temporary frame to clone the selection for export
+  const temp = figma.createFrame();
+  temp.name = "__temp_export__";
+  temp.fills = [];
+  figma.currentPage.appendChild(temp);
+
+  for (const node of selection) {
+    const clone = node.clone();
+    temp.appendChild(clone);
+  }
+
+  const bytes = await temp.exportAsync({
+    format: "JPG",
+    constraint: { type: "SCALE", value: scale },
+  });
+
+  temp.remove();
+
+  return {
+    format: "JPG",
+    mimeType: "image/jpeg",
+    imageData: customBase64Encode(bytes),
+  };
+}
 function customBase64Encode(bytes) {
   const chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -1665,6 +1732,82 @@ async function cloneNode(params) {
     width: "width" in clone ? clone.width : undefined,
     height: "height" in clone ? clone.height : undefined,
   };
+}
+
+// Clone node and return mapping from original IDs to clone IDs
+async function cloneNodeWithMap(params) {
+  const { nodeId, x, y } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  const clone = node.clone();
+
+  if (x !== undefined && y !== undefined) {
+    if ("x" in clone && "y" in clone) {
+      clone.x = x;
+      clone.y = y;
+    }
+  }
+
+  if (node.parent) {
+    node.parent.appendChild(clone);
+  } else {
+    figma.currentPage.appendChild(clone);
+  }
+
+  const idMap = {};
+  function mapIds(orig, dup) {
+    idMap[orig.id] = dup.id;
+    if ("children" in orig && "children" in dup) {
+      for (let i = 0; i < orig.children.length; i++) {
+        mapIds(orig.children[i], dup.children[i]);
+      }
+    }
+  }
+  mapIds(node, clone);
+
+  return {
+    id: clone.id,
+    name: clone.name,
+    idMap,
+  };
+}
+
+// Get hierarchical tree for a node
+async function getNodeTree(params) {
+  const { nodeId } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId parameter");
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found with ID: ${nodeId}`);
+
+  function traverse(n) {
+    const info = { id: n.id, name: n.name, type: n.type };
+    if ("children" in n) {
+      info.children = n.children.map(traverse);
+    }
+    return info;
+  }
+  return traverse(node);
+}
+
+// Get hierarchical tree for the current page
+async function getCurrentPageTree() {
+  const page = figma.currentPage;
+  function traverse(n) {
+    const info = { id: n.id, name: n.name, type: n.type };
+    if ("children" in n) {
+      info.children = n.children.map(traverse);
+    }
+    return info;
+  }
+  return traverse(page);
 }
 
 async function scanTextNodes(params) {

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -151,6 +151,70 @@ server.tool(
   }
 );
 
+// Select Nodes Tool
+server.tool(
+  "select_nodes",
+  "Select nodes on the canvas by their IDs",
+  {
+    nodeIds: z.array(z.string()).describe("Array of node IDs to select")
+  },
+  async ({ nodeIds }) => {
+    try {
+      const result = await sendCommandToFigma("select_nodes", { nodeIds });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error selecting nodes: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Export Selection Tool
+server.tool(
+  "get_selection_base64",
+  "Export the current selection as a JPG and return the base64 string",
+  {
+    scale: z.number().positive().optional().describe("Export scale")
+  },
+  async ({ scale }) => {
+    try {
+      const result = await sendCommandToFigma("get_selection_base64", { scale });
+      const typed = result as { imageData: string; mimeType: string };
+      return {
+        content: [
+          {
+            type: "image",
+            data: typed.imageData,
+            mimeType: typed.mimeType || "image/jpeg"
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error exporting selection: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
 // Read My Design Tool
 server.tool(
   "read_my_design",
@@ -348,6 +412,66 @@ server.tool(
               }`,
           },
         ],
+      };
+    }
+  }
+);
+
+// Node Tree Tool
+server.tool(
+  "get_node_tree",
+  "Get the hierarchical tree of a node and its children",
+  {
+    nodeId: z.string().describe("ID of the node to inspect")
+  },
+  async ({ nodeId }) => {
+    try {
+      const result = await sendCommandToFigma("get_node_tree", { nodeId });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting node tree: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Current Page Tree Tool
+server.tool(
+  "get_current_page_tree",
+  "Get the hierarchical tree of the current page",
+  {},
+  async () => {
+    try {
+      const result = await sendCommandToFigma("get_current_page_tree", {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting page tree: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
       };
     }
   }
@@ -747,6 +871,39 @@ server.tool(
           {
             type: "text",
             text: `Error cloning node: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Clone Node with Map Tool
+server.tool(
+  "clone_node_with_map",
+  "Clone a node and get a mapping of original IDs to cloned IDs",
+  {
+    nodeId: z.string().describe("The ID of the node to clone"),
+    x: z.number().optional().describe("New X position for the clone"),
+    y: z.number().optional().describe("New Y position for the clone")
+  },
+  async ({ nodeId, x, y }) => {
+    try {
+      const result = await sendCommandToFigma('clone_node_with_map', { nodeId, x, y });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error cloning node with map: ${error instanceof Error ? error.message : String(error)}`
           }
         ]
       };
@@ -2568,6 +2725,7 @@ type FigmaCommand =
   | "join"
   | "set_corner_radius"
   | "clone_node"
+  | "clone_node_with_map"
   | "set_text_content"
   | "scan_text_nodes"
   | "set_multiple_text_contents"
@@ -2582,7 +2740,11 @@ type FigmaCommand =
   | "set_item_spacing"
   | "get_reactions"
   | "set_default_connector"
-  | "create_connections";
+  | "create_connections"
+  | "get_node_tree"
+  | "get_current_page_tree"
+  | "select_nodes"
+  | "get_selection_base64";
 
 type CommandParams = {
   get_document_info: Record<string, never>;
@@ -2685,6 +2847,11 @@ type CommandParams = {
     x?: number;
     y?: number;
   };
+  clone_node_with_map: {
+    nodeId: string;
+    x?: number;
+    y?: number;
+  };
   set_text_content: {
     nodeId: string;
     text: string;
@@ -2725,7 +2892,12 @@ type CommandParams = {
       text?: string;
     }>;
   };
-  
+
+  get_node_tree: { nodeId: string };
+  get_current_page_tree: Record<string, never>;
+  select_nodes: { nodeIds: string[] };
+  get_selection_base64: { scale?: number };
+
 };
 
 


### PR DESCRIPTION
## Summary
- allow the plugin to select nodes and export selection images
- expose `select_nodes` and `get_selection_base64` tools in the MCP server
- document the new commands in the README

## Testing
- `bun run build` *(fails: tsup not found)*